### PR TITLE
Feat/주점별좋아요api구현 (SSE 방식)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'com.hyyh'
@@ -34,6 +35,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hyyh/festa/FestaApplication.java
+++ b/src/main/java/com/hyyh/festa/FestaApplication.java
@@ -2,8 +2,10 @@ package com.hyyh.festa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FestaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hyyh/festa/controller/LikeController.java
+++ b/src/main/java/com/hyyh/festa/controller/LikeController.java
@@ -1,0 +1,24 @@
+package com.hyyh.festa.controller;
+
+import com.hyyh.festa.service.SseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final SseService sseService;
+
+    // UTF-8 데이터만 보낼 수 있음, 바이너리 데이터 지원 x
+    @GetMapping(path = "/like", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(){
+        //SseEmitter는 서버에서 클라이언트로 이벤트를 전달할 수 있습니다.
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        sseService.addEmitter(emitter);
+        return emitter;
+    }
+}

--- a/src/main/java/com/hyyh/festa/controller/PubController.java
+++ b/src/main/java/com/hyyh/festa/controller/PubController.java
@@ -1,0 +1,27 @@
+package com.hyyh.festa.controller;
+
+import com.hyyh.festa.repository.PubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PubController {
+
+    private final PubRepository pubRepository;
+
+    @PostMapping("/{pubId}/like")
+    public ResponseEntity<?> likePub(@PathVariable("pubId") Integer pubId) {
+
+        /*
+         * pubId 에 해당하는 주점의 좋아요 수를 증가시키는 로직
+         *
+         * */
+        pubRepository.plusLike(pubId);
+
+        return ResponseEntity.status(200).body("좋아요 성공");
+    }
+}

--- a/src/main/java/com/hyyh/festa/controller/PubController.java
+++ b/src/main/java/com/hyyh/festa/controller/PubController.java
@@ -1,27 +1,19 @@
 package com.hyyh.festa.controller;
 
-import com.hyyh.festa.repository.PubRepository;
-import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "주점", description = "주점 관련하여 CRUD를 담당하는 API 입니다.")
+@RequestMapping
 @RestController
-@RequiredArgsConstructor
-public class PubController {
-
-    private final PubRepository pubRepository;
-
+public interface PubController {
+    @Operation(summary = "리스트뷰 일기 조회 ", description = "QueryString 을 이용해 일기(리스트뷰)조회를 합니다.")
     @PostMapping("/{pubId}/like")
-    public ResponseEntity<?> likePub(@PathVariable("pubId") Integer pubId) {
-
-        /*
-         * pubId 에 해당하는 주점의 좋아요 수를 증가시키는 로직
-         *
-         * */
-        pubRepository.plusLike(pubId);
-
-        return ResponseEntity.status(200).body("좋아요 성공");
-    }
+    ResponseEntity<?> likePub(@PathVariable("pubId") @Parameter(name = "주점Id", description = "좋아요 할 주점 Id", required = true) Integer pubId);
 }

--- a/src/main/java/com/hyyh/festa/controller/PubControllerImpl.java
+++ b/src/main/java/com/hyyh/festa/controller/PubControllerImpl.java
@@ -1,0 +1,27 @@
+package com.hyyh.festa.controller;
+
+import com.hyyh.festa.repository.PubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PubControllerImpl implements PubController{
+
+    private final PubRepository pubRepository;
+
+    @PostMapping("/{pubId}/like")
+    public ResponseEntity<?> likePub(@PathVariable("pubId") Integer pubId) {
+
+        /*
+         * pubId 에 해당하는 주점의 좋아요 수를 증가시키는 로직
+         *
+         * */
+        pubRepository.plusLike(pubId);
+
+        return ResponseEntity.status(200).body("좋아요 성공");
+    }
+}

--- a/src/main/java/com/hyyh/festa/domain/Pub.java
+++ b/src/main/java/com/hyyh/festa/domain/Pub.java
@@ -1,0 +1,22 @@
+package com.hyyh.festa.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Pub {
+
+    public Integer pubId;
+    public Integer likeCount;
+
+    public Pub(Integer pubId, Integer likeCount) {
+        this.pubId = pubId;
+        this.likeCount = likeCount;
+    }
+
+    public void plusLike() {
+        this.likeCount += 1;
+    }
+}
+

--- a/src/main/java/com/hyyh/festa/repository/PubRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/PubRepository.java
@@ -1,0 +1,39 @@
+package com.hyyh.festa.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyyh.festa.domain.Pub;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class PubRepository {
+    private static final ConcurrentHashMap<Integer, Pub> pubs = new ConcurrentHashMap<Integer, Pub>();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @PostConstruct
+    private void initializePub() {
+        pubs.put(1, new Pub(1, 0));
+        pubs.put(2, new Pub(2, 0));
+        pubs.put(3, new Pub(3, 0));
+    }
+    public void plusLike(Integer pubId) {
+        Pub pub = pubs.get(pubId);
+        pub.plusLike();
+        pubs.put(pubId, pub);
+    }
+
+    public String getAllPubs() {
+        try {
+            List<Pub> pubList = new ArrayList<>(pubs.values());
+            return objectMapper.writeValueAsString(pubList);
+        } catch (JsonProcessingException e) {
+            // Exception handling (you might want to log the error)
+            e.printStackTrace();
+            return "Error converting to JSON";
+        }
+    }
+}

--- a/src/main/java/com/hyyh/festa/service/SseService.java
+++ b/src/main/java/com/hyyh/festa/service/SseService.java
@@ -1,0 +1,39 @@
+package com.hyyh.festa.service;
+
+import com.hyyh.festa.repository.PubRepository;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class SseService {
+    /*
+     * 주로 순회가 일어나는 용도로 사용할 때는 안전한 스레드 처리를 위해 CopyOnWriteArrayList를 사용
+     */
+    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    private final PubRepository pubRepository;
+
+    public void addEmitter(SseEmitter emitter) {
+        emitters.add(emitter);
+        emitter.onCompletion(() -> emitters.remove(emitter));
+        emitter.onTimeout(() -> emitters.remove(emitter));
+    }
+
+    @Scheduled(fixedRate = 1000)
+    public void sendEvents() {
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(pubRepository.getAllPubs());
+            } catch (IOException e) {
+                emitter.complete();
+                emitters.remove(emitter);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
아직 ERD가 확정되지 않았기 때문에 임시 Pub Entity 와 Repository 를 생성했습니다.
PubRepository 에는 @PostContruct 어노테이션을 사용해 pub 객체를 3개로 초기화 해주었습니다.

pubRepository.getAllPubs 메서드는 현재 pubs HashMap 에 저장된 객체들을 아래와 같이 String 형태로 바꿔 리턴해줍니다.
![image](https://github.com/user-attachments/assets/2f3d972d-b20c-403c-982a-a6d4585e57be)

post "/:pubId/like" API 를 통해 좋아요 API를 구현했습니다.

SseService 의 sendEvents 함수를 통하여 서버를 Subscribe 하고 있는 모든 client 에게 매 1초마다 pubRepository 에 저장된 좋아요 갯수 정보를 sendMessage 해줍니다. 
클라이언트는 EventSource 객체를 통하여 서버를 구독(Subscribe) 하고있어야 합니다.
 
## 📸 작업 화면 스크린샷

https://github.com/user-attachments/assets/2fd620d5-d0a0-4e3c-b4d9-6e7f8db7b4e0

localhost:8080/swagger 를 통해 API 문서 확인이 가능합니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

