### PR TITLE
[Feat] 카카오, Admin 로그인을 위한 토큰 설정

### DIFF
--- a/src/main/java/com/hyyh/festa/config/SecurityConfig.java
+++ b/src/main/java/com/hyyh/festa/config/SecurityConfig.java
@@ -34,7 +34,9 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/admin/login").permitAll())
+                        .requestMatchers("/admin/login").permitAll()
+                        .requestMatchers("/kakao/login").permitAll()
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/com/hyyh/festa/controller/AuthenticationController.java
+++ b/src/main/java/com/hyyh/festa/controller/AuthenticationController.java
@@ -1,12 +1,17 @@
 package com.hyyh.festa.controller;
 
+import com.hyyh.festa.domain.FestaUser;
+import com.hyyh.festa.dto.KakaoLoginRequest;
 import com.hyyh.festa.dto.LoginRequest;
 import com.hyyh.festa.dto.TokenResponse;
 import com.hyyh.festa.jwt.JwtUtil;
+import com.hyyh.festa.oidc.OidcUtil;
+import com.hyyh.festa.repository.FestaUserRepository;
 import com.hyyh.festa.service.AuthenticationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,7 +20,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthenticationController {
     private final AuthenticationService authenticationService;
+    private final FestaUserRepository festaUserRepository;
+    private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
+    private final OidcUtil oidcUtil;
 
     @PostMapping("/admin/login")
     public ResponseEntity<?> loginAdminUser(@RequestBody LoginRequest loginRequest) {
@@ -29,6 +37,31 @@ public class AuthenticationController {
             return ResponseEntity
                     .status(401)
                     .body("인증이 실패했다는 메시지");
+        }
+    }
+
+    @PostMapping("/kakao/login")
+    public ResponseEntity<?> loginFestaUser(@RequestBody KakaoLoginRequest kakaoLoginRequest) throws Exception {
+        // ‼️ for test
+        // ‼️ for test
+        String idToken = oidcUtil.generateKakaoIdToken(kakaoLoginRequest.getAccessCode());
+        String kakaoSub = oidcUtil.extractSubFromKakaoIdToken(idToken);
+
+        FestaUser findFestaUser = festaUserRepository.findByKakaoSub(kakaoSub).orElse(null);
+
+        if (findFestaUser != null) {
+            return ResponseEntity
+                    .status(200)
+                    .body(jwtUtil.generateToken(findFestaUser));
+        } else {
+            FestaUser newFestaUser = FestaUser.builder()
+                    .kakaoSub(kakaoSub)
+                    .password(passwordEncoder.encode("abc"))
+                    .build();
+            festaUserRepository.save(newFestaUser);
+            return ResponseEntity
+                    .status(200)
+                    .body(jwtUtil.generateToken(newFestaUser));
         }
     }
 }

--- a/src/main/java/com/hyyh/festa/domain/FestaUser.java
+++ b/src/main/java/com/hyyh/festa/domain/FestaUser.java
@@ -1,0 +1,49 @@
+package com.hyyh.festa.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FestaUser implements UserDetails {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String kakaoSub;
+
+    private String password;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+                new GrantedAuthority() {
+                    @Override
+                    public String getAuthority() {
+                        return "USER";
+                    }
+                }
+        );
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return kakaoSub;
+    }
+}

--- a/src/main/java/com/hyyh/festa/domain/KakaoPublicKey.java
+++ b/src/main/java/com/hyyh/festa/domain/KakaoPublicKey.java
@@ -1,0 +1,27 @@
+package com.hyyh.festa.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class KakaoPublicKey {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String kid;
+    @Column(length = 800)
+    private String n;
+    private String e;
+    private LocalDateTime lastUpdated;
+
+}

--- a/src/main/java/com/hyyh/festa/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/hyyh/festa/dto/KakaoLoginRequest.java
@@ -1,0 +1,14 @@
+package com.hyyh.festa.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class KakaoLoginRequest {
+
+    private String accessCode;
+
+}

--- a/src/main/java/com/hyyh/festa/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hyyh/festa/jwt/JwtAuthenticationFilter.java
@@ -13,6 +13,6 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/hyyh/festa/jwt/JwtUtil.java
+++ b/src/main/java/com/hyyh/festa/jwt/JwtUtil.java
@@ -1,37 +1,95 @@
 package com.hyyh.festa.jwt;
 
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.security.Keys;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyyh.festa.domain.KakaoPublicKey;
+import com.hyyh.festa.repository.KakaoPublicKeyRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 import javax.crypto.SecretKey;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.LocalDateTime;
 import java.util.Base64;
+import java.util.Date;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class JwtUtil {
     private final SecretKey secretKey;
+    private static final String AUTHORITIES_KEY = "authority";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 30;
 
-    public JwtUtil() {
+    public JwtUtil(KakaoPublicKeyRepository kakaoPublicKeyRepository) {
         // todo: 배포 시에는 32비트 비밀키 값 base64로 인코딩 => path var로 분리
         // 현재는 테스트용 비밀키
         secretKey = Keys.hmacShaKeyFor(
-                Base64.getDecoder().decode("fgdfghdfhdfgdgdsgfdsgfdgdfsgdchgfbnfdntdrfgdfghdfhdfgdgdsgfdsgfdgdfsgdchgfbnfdntdr"));
+                Base64.getDecoder().decode("fgdfghdfhdfgdgdsgfdsgfdgdfsgdchgfbnfdntdrfgdfghdfhdfgdgdsgfdsgfdgdfsgdchgfbnfdntdrfgdfghdfhdfgdgdsgfdsgfdgdfsgdchgfbnfdntdrfgdfghdfhdfgdgdsgfdsgfdgdfsgdchgfbnfdntdr"));
     }
 
     public String generateToken(UserDetails userDetails) {
-        return null;
+        String authorities = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date tokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        System.out.println("tokenExpiresIn = " + tokenExpiresIn);
+
+        String accessToken = Jwts.builder()
+                .subject(userDetails.getUsername())
+                .issuer("HIFesta")
+                .claim(AUTHORITIES_KEY, authorities)
+                .expiration(tokenExpiresIn)
+                .signWith(secretKey)
+                .compact();
+
+        validate(accessToken);
+
+        return accessToken;
     }
 
     public void validate(String token) throws JwtException {
-
-    }
-
-    public void validateKakaoOpenId(String idToken) throws Exception {
-
+        try {
+            Jws<Claims> claimsJws = Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token);
+            System.out.println("claimsJws.getBody().get(\"sub\") = " + claimsJws.getBody().get("sub"));
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
     }
 
     public String extractUsertype(String token) {
-        return null;
+        try {
+            Claims claims = Jwts.parser().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+            return claims.get(AUTHORITIES_KEY, String.class);
+        } catch (JwtException e) {
+            log.error("토큰에서 사용자 타입을 추출할 수 없습니다: {}", e.getMessage());
+            return null;
+        }
     }
+
 }

--- a/src/main/java/com/hyyh/festa/oidc/OidcUtil.java
+++ b/src/main/java/com/hyyh/festa/oidc/OidcUtil.java
@@ -1,0 +1,246 @@
+package com.hyyh.festa.oidc;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hyyh.festa.domain.KakaoPublicKey;
+import com.hyyh.festa.repository.KakaoPublicKeyRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OidcUtil {
+    private static final String REST_API_KEY = "2f3d082cf01130dd3a9ced2eb17c92fd";
+    private static final String REST_API_SECRET = "5eyYM5Esv2v4IlB1moPxEhJiVJfleaoF";
+    private static final String REDIRECT_URI = "http://localhost:8080/login/oauth2/code/kakao";
+    private final KakaoPublicKeyRepository kakaoPublicKeyRepository;
+
+    public String generateKakaoIdToken(String accessCode) throws JsonProcessingException {
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+//
+//        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+//        body.add("grant_type", "authorization_code");
+//        body.add("client_id", REST_API_KEY);
+//        body.add("redirect_uri", REDIRECT_URI);
+//        body.add("code", accessCode);
+//        body.add("client_secret", REST_API_SECRET);
+//
+//        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+//        RestTemplate rt = new RestTemplate();
+//        ResponseEntity<String> response = rt.exchange(
+//                "https://kauth.kakao.com/oauth/token",
+//                HttpMethod.POST,
+//                kakaoTokenRequest,
+//                String.class
+//        );
+//
+//        String responseBody = response.getBody();
+//        ObjectMapper objectMapper = new ObjectMapper();
+//
+//        JsonNode jsonNode = objectMapper.readTree(responseBody);
+//
+//        return jsonNode.get("id_token").asText();
+//
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", REST_API_KEY);
+        body.add("redirect_uri", REDIRECT_URI);
+        body.add("code", accessCode);
+        body.add("client_secret", REST_API_SECRET);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(body, headers);
+        RestTemplate rt = new RestTemplate();
+
+        try {
+            ResponseEntity<String> response = rt.exchange(
+                    "https://kauth.kakao.com/oauth/token",
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    String.class
+            );
+
+            String responseBody = response.getBody();
+            if (responseBody == null) {
+                throw new RuntimeException("카카오 API에서 응답 body를 얻는 중 문제가 발생했습니다.");
+            }
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+            if (jsonNode.has("id_token")) {
+                return jsonNode.get("id_token").asText();
+            } else {
+                throw new RuntimeException("카카오 API의 응답에 id_token이 없습니다.");
+            }
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            throw new RuntimeException("카카오 ID token을 얻는 중 HTTP 오류가 발생했습니다 : " + e.getMessage(), e);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("카카오 API의 응답에서 JSON을 처리하는 과정에서 오류가 발생했습니다 : " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new RuntimeException("예상치 못한 오류가 발생했습니다 : " + e.getMessage(), e);
+        }
+    }
+
+    public String extractSubFromKakaoIdToken(String idToken) throws Exception {
+        String jwksUrl = "https://kauth.kakao.com/.well-known/jwks.json";
+        String kid = getKidFromToken(idToken);
+        PublicKey publicKey = getPublicKey(kid, jwksUrl);
+
+        Jws<Claims> claims = Jwts.parser()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(idToken);
+
+        validateKakaoIdTokenClaims(claims.getBody());
+
+        log.info("카카오 id 토큰 검증이 완료되었습니다.");
+        return claims.getBody().getSubject();
+    }
+
+    private String getKidFromToken(String idToken) throws Exception {
+//        String[] idTokenParts = idToken.split("\\.");
+//        String headerJson = new String(Base64.getUrlDecoder().decode(idTokenParts[0]));
+//        ObjectMapper mapper = new ObjectMapper();
+//        JsonNode header = mapper.readTree(headerJson);
+//        return header.get("kid").asText();
+
+        if (idToken == null || idToken.split("\\.").length != 3) {
+            throw new IllegalArgumentException("유효하지 않은 토큰 형식입니다.");
+        }
+
+        try {
+            String[] idTokenParts = idToken.split("\\.");
+            String headerJson = new String(Base64.getUrlDecoder().decode(idTokenParts[0]));
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode header = mapper.readTree(headerJson);
+            if (header.has("kid")) {
+                return header.get("kid").asText();
+            } else {
+                throw new RuntimeException("헤더에 kid 필드가 없습니다.");
+            }
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("JWT header를 디코딩하는 중 오류가 발생했습니다 : " + e.getMessage(), e);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JWT header를 JSON으로 처리하는 중 오류가 발생했습니다 : " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new RuntimeException("예상치 못한 오류가 발생했습니다 : " + e.getMessage(), e);
+        }
+    }
+
+    private PublicKey getPublicKey(String kid, String jwksUrl) throws Exception {
+        KakaoPublicKey kakaoPublicKey = kakaoPublicKeyRepository.findByKid(kid).orElse(null);
+
+        if (kakaoPublicKey != null) {
+            return createPublicKey(kakaoPublicKey.getN(), kakaoPublicKey.getE());
+        }
+
+        PublicKey publicKey = fetchAndStorePublicKey(kid, jwksUrl);
+        if (publicKey == null) {
+            throw new IllegalArgumentException("새로운 카카오 공개 키를 받는 중 오류가 발생했습니다.");
+        }
+
+        return publicKey;
+    }
+
+    private PublicKey createPublicKey(String n, String e) throws Exception {
+//        byte[] nBytes = Decoders.BASE64URL.decode(n);
+//        byte[] eBytes = Decoders.BASE64URL.decode(e);
+//        RSAPublicKeySpec spec = new RSAPublicKeySpec(new java.math.BigInteger(1, nBytes), new java.math.BigInteger(1, eBytes));
+//        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+//        return keyFactory.generatePublic(spec);
+//
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(n);
+            byte[] eBytes = Base64.getUrlDecoder().decode(e);
+
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(
+                    new BigInteger(1, nBytes),
+                    new BigInteger(1, eBytes)
+            );
+
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            return keyFactory.generatePublic(spec);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Base64URL 문자열을 RSA 키 파라미터로 디코딩하는 중 오류가 발생했습니다 : " + ex.getMessage(), ex);
+        } catch (Exception ex) {
+            // Handle any other unexpected errors
+            throw new RuntimeException("RSA 키를 만드는 중 예상치 못한 오류가 발생했습니다 : " + ex.getMessage(), ex);
+        }
+
+    }
+
+    private PublicKey fetchAndStorePublicKey(String kid, String jwksUrl) throws Exception {
+        URL url = new URL(jwksUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode jwks = mapper.readTree(connection.getInputStream());
+
+            for (JsonNode key : jwks.get("keys")) {
+                if (key.get("kid").asText().equals(kid)) {
+                    String n = key.get("n").asText();
+                    String e = key.get("e").asText();
+                    PublicKey publicKey = createPublicKey(n, e);
+
+                    KakaoPublicKey kakaoPublicKey = new KakaoPublicKey();
+                    kakaoPublicKey.setKid(kid);
+                    kakaoPublicKey.setN(n);
+                    kakaoPublicKey.setE(e);
+                    kakaoPublicKey.setLastUpdated(LocalDateTime.now());
+                    kakaoPublicKeyRepository.save(kakaoPublicKey);
+
+                    return publicKey;
+                }
+            }
+        } catch (IOException e) {
+            throw new IOException("카카오에서 공개키를 가져오는 과정에서 오류가 발생했습니다 : " + e.getMessage(), e);
+        }
+        return null;
+    }
+
+    private void validateKakaoIdTokenClaims(Claims claims) {
+        if (!claims.getIssuer().equals("https://kauth.kakao.com")) {
+            throw new IllegalArgumentException("토큰 발행처가 다릅니다.");
+        }
+        if (claims.getExpiration().before(new Date())) {
+            throw new IllegalArgumentException("토큰이 만료되었습니다.");
+        }
+        if (!claims.getAudience().contains(REST_API_KEY)) {
+            throw new IllegalArgumentException("축제 사이트를 위한 토큰이 아닙니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/hyyh/festa/repository/FestaUserRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/FestaUserRepository.java
@@ -1,0 +1,12 @@
+package com.hyyh.festa.repository;
+
+import com.hyyh.festa.domain.FestaUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FestaUserRepository extends JpaRepository<FestaUser, Long> {
+
+    Optional<FestaUser> findByKakaoSub (String kakaoSub);
+
+}

--- a/src/main/java/com/hyyh/festa/repository/KakaoPublicKeyRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/KakaoPublicKeyRepository.java
@@ -1,0 +1,12 @@
+package com.hyyh.festa.repository;
+
+import com.hyyh.festa.domain.KakaoPublicKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface KakaoPublicKeyRepository extends JpaRepository<KakaoPublicKey, Long> {
+
+    Optional<KakaoPublicKey> findByKid(String kid);
+
+}


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
1. 카카오 로그인 시, id token에서 sub을 얻어와 그것을 username으로 하는 UserDetails 구현체 인스턴스를 만듭니다.
2. 카카오 최초 로그인 시, 해당 UserDetails의 password는 암호화된 abc라는 문자열로 설정됩니다.
3. id token을 위한 공개키는 KakaoPublicKey라는 엔티티로, db에 저장됩니다. 유효하는 공개키가 없게 될 시에는 카카오에게서 다시 가져옵니다.
4. AdminUser, FestaUser 모두 우리 서비스의 jwt에 대해서는 같은 사양을 가집니다. iss, sub, authority, exp를 포함합니다.
5. AuthenticationController의 /kakao/login에 해당하는 메서드는 테스트용입니다. 추후 변경해서 사용해야 합니다.

## 📸 작업 화면 스크린샷
![1](https://github.com/user-attachments/assets/2670a9cc-1257-42a4-a0cf-6764e91108e6)
테스트용 컨트롤러
<br>
<img width="807" alt="2" src="https://github.com/user-attachments/assets/3081da08-742c-4091-9225-506b37e570fc">
테스트용 카카오 애플리케이션을 만들고, access code를 얻어 진행했습니다.
<br>
<img width="985" alt="3" src="https://github.com/user-attachments/assets/31fdbea8-2c4e-4e98-94c7-ead13f317e2d">
응답으로 받은 우리 서비스의 토큰에는 sub, iss, authority, exp가 payload로 포함됩니다.
<br>
<img width="1248" alt="4" src="https://github.com/user-attachments/assets/09efec66-5ef4-41b1-a5b3-8bc476666748">
<img width="571" alt="5" src="https://github.com/user-attachments/assets/44d94d11-ec86-43d2-a5a2-d7e3df367bc9">
db에는 새로운 공개키와 새로운 카카오 회원이 생깁니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]