### PR TITLE
[Feat] RestAPI 응답바디를 위한 reponseDTO 구현

### DIFF
--- a/src/main/java/com/hyyh/festa/domain/ResponseDTO.java
+++ b/src/main/java/com/hyyh/festa/domain/ResponseDTO.java
@@ -32,6 +32,13 @@ public class ResponseDTO<T> {
     public static <T> ResponseDTO<T> internalServerError(String message) {
         return new ResponseDTO<>(HttpStatus.INTERNAL_SERVER_ERROR.value(), message, null);
     }
+    public static <T> ResponseDTO<T> unauthorized(String message) {
+        return new ResponseDTO<>(HttpStatus.UNAUTHORIZED.value(), message, null);
+    }
+
+    public static <T> ResponseDTO<T> forbidden(String message) {
+        return new ResponseDTO<>(HttpStatus.FORBIDDEN.value(), message, null);
+    }
 
     // 사용자 정의 HttpStatus 처리
     public static <T> ResponseDTO<T> custom(HttpStatus status, String message, T data) {


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
- server 측 RestAPI 설계 시
응답바디의 통일성을 위하여 사용할 수 있는 responseDTO가 필요하다.
- 자주쓰이는 HttpStatus는 클래스 내 public 메서드로 만들어둠으로써, 사용할 때 해당 메서드와 함께 (message, data)만 넘겨주면 된다. 사용자 정의가 가능하도록 추가적인 메서드도 구현해놓았다.
- Controller에서 responseEntity<responseDTO<객체>> 형태로 사용하면 된다.

## 📸 작업 화면 스크린샷
<img width="1392" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/c9ba6808-9478-4e04-8d92-a18fb232b21a">
<img width="1392" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/210b5b6b-1a34-4a81-8d46-e3fd1208a2b2">
<img width="1392" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/943f3cdc-c2ec-48b9-a22a-f8631abc8568">
<img width="1392" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/384109ad-744f-49c2-a64f-b359dd305f23">
<img width="1392" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/6c6b8529-6fe1-4ee5-8192-d01ca4860f44">

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [ ] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]