### PR TITLE
[Feat] 카카오 로그인 시 Redirect URI로 분기 구현

### DIFF
--- a/src/main/java/com/hyyh/festa/domain/TokenType.java
+++ b/src/main/java/com/hyyh/festa/domain/TokenType.java
@@ -1,0 +1,5 @@
+package com.hyyh.festa.domain;
+
+public enum TokenType {
+    LOST, ENTRY
+}

--- a/src/main/java/com/hyyh/festa/oidc/KakaoErrorException.java
+++ b/src/main/java/com/hyyh/festa/oidc/KakaoErrorException.java
@@ -1,0 +1,13 @@
+package com.hyyh.festa.oidc;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoErrorException extends RuntimeException {
+    private final String errorCode;
+
+    public KakaoErrorException(String message, String errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/hyyh/festa/oidc/OidcUtil.java
+++ b/src/main/java/com/hyyh/festa/oidc/OidcUtil.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyyh.festa.domain.KakaoPublicKey;
+import com.hyyh.festa.domain.TokenType;
 import com.hyyh.festa.repository.KakaoPublicKeyRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -43,19 +44,27 @@ public class OidcUtil {
     @Value("${KAKAO_REST_API_SECRET}")
     private String REST_API_SECRET;
 
-    @Value("${KAKAO_REST_API_REDIRECT_URI}")
-    private String REDIRECT_URI;
+    @Value("${KAKAO_REST_API_ENTRY_REDIRECT_URI}")
+    private String ENTRY_REDIRECT_URI;
+
+    @Value("${KAKAO_REST_API_LOST_REDIRECT_URI}")
+    private String LOST_REDIRECT_URI;
 
     private final KakaoPublicKeyRepository kakaoPublicKeyRepository;
 
-    public String generateKakaoIdToken(String accessCode) throws JsonProcessingException {
+    public String generateKakaoIdToken(String accessCode, TokenType tokenType) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", REST_API_KEY);
-        body.add("redirect_uri", REDIRECT_URI);
+        if (tokenType == TokenType.ENTRY) {
+            body.add("redirect_uri", ENTRY_REDIRECT_URI);
+        }
+        else if (tokenType == TokenType.LOST) {
+            body.add("redirect_uri", LOST_REDIRECT_URI);
+        }
         body.add("code", accessCode);
         body.add("client_secret", REST_API_SECRET);
 

--- a/src/main/java/com/hyyh/festa/service/AuthenticationService.java
+++ b/src/main/java/com/hyyh/festa/service/AuthenticationService.java
@@ -1,6 +1,8 @@
 package com.hyyh.festa.service;
 
 import com.hyyh.festa.domain.FestaUser;
+import com.hyyh.festa.domain.TokenType;
+import com.hyyh.festa.oidc.KakaoErrorException;
 import com.hyyh.festa.oidc.OidcUtil;
 import com.hyyh.festa.repository.FestaUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -31,13 +36,22 @@ public class AuthenticationService {
         return (UserDetails) authentication.getPrincipal();
     }
 
-    public UserDetails authenticateFestaUser(String code) {
+    public UserDetails authenticateFestaUser(String code, TokenType tokenType) {
         String kakaoSub = null;
         try {
-            String idToken = oidcUtil.generateKakaoIdToken(code);
+            String idToken = oidcUtil.generateKakaoIdToken(code, tokenType);
             kakaoSub = oidcUtil.extractSubFromKakaoIdToken(idToken);
         } catch (Exception e) {
-            return null;
+            String eMessage = e.getMessage();
+            String regex = "\"error_code\":\"(.*?)\"";
+            Pattern pattern = Pattern.compile(regex);
+            Matcher matcher = pattern.matcher(eMessage);
+
+            String matchString = "UNKNOWN";
+            if (matcher.find()) {
+                matchString = matcher.group(1);
+            }
+            throw new KakaoErrorException("인가 코드 처리 중 오류가 발생했습니다.", matchString);
         }
 
         FestaUser festaUser = festaUserRepository


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [x] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
1. 인가 코드를 받고, 그 인가 코드의 Redirect URI에 맞지 않은 엔드포인트로 토큰을 요청 시 예외를 발생시킵니다.
2. 추가적으로, 만료된 인가 코드를 사용할 시에도 해당 사실을 알리는 예외를 발생시킵니다.
3. 만료된 인가 코드, 적절하지 않은 Redirect URI는 카카오가 제공하는 오류 코드로 판단합니다.

## 📸 작업 화면 스크린샷
<img width="790" alt="스크린샷 2024-07-29 오후 4 02 23" src="https://github.com/user-attachments/assets/2ae4d9ab-c1ee-4caa-a965-61ccf6869f55">
분실물 게시판용 인가 코드로 이벤트 응모 토큰을 요청 시 예외가 발생합니다.
<br>
<img width="793" alt="스크린샷 2024-07-29 오후 4 02 48" src="https://github.com/user-attachments/assets/3eb0efad-03ec-4f5e-9102-fc60ae7166af">
이벤트 응모 토큰 발급에 인가 코드를 재사용할 시 예외가 발생합니다.
<br>
<img width="793" alt="스크린샷 2024-07-29 오후 4 03 29" src="https://github.com/user-attachments/assets/5e230f50-621f-4134-ae05-d8b262f6dcab">
이벤트 응모용 인가 코드로 분실물 게시판 토큰을 요청 시 예외가 발생합니다.
<br>
<img width="783" alt="스크린샷 2024-07-29 오후 4 03 04" src="https://github.com/user-attachments/assets/add719cd-f19d-44ca-b6d5-60a730805db3">
분실물 게시판 토큰 발급에 인가 코드를 재사용할 시 예외가 발생합니다.
<br>

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]