### PR TITLE
[Feat] 이벤트 응모 정당성 검증 로직 구현

### DIFF
--- a/src/main/java/com/hyyh/festa/repository/EntryRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/EntryRepository.java
@@ -1,7 +1,9 @@
 package com.hyyh.festa.repository;
 
 import com.hyyh.festa.domain.Entry;
+import com.hyyh.festa.domain.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,6 @@ import java.util.List;
 @Repository
 public interface EntryRepository extends JpaRepository<Entry, Long> {
     List<Entry> findAllByEventId(Long eventId);
+
+    boolean existsByUserAndEvent(UserDetails festaUser, Event event);
 }

--- a/src/main/java/com/hyyh/festa/service/ValidationService.java
+++ b/src/main/java/com/hyyh/festa/service/ValidationService.java
@@ -1,6 +1,10 @@
 package com.hyyh.festa.service;
 
+import com.hyyh.festa.domain.Event;
+import com.hyyh.festa.repository.EntryRepository;
+import com.hyyh.festa.repository.EventRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -8,12 +12,37 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 public class ValidationService {
-    public boolean isEventApplicable(Long eventId) {
-        return true;
+    private static final double HIU_LAT = 37.55073164533574;
+    private static final double HIU_LON = 126.92549763193347;
+    private static final int EARTH_RADIUS = 6371;
+
+    private final EventRepository eventRepository;
+    private final EntryRepository entryRepository;
+
+    public char isEventApplicable(Long eventId, UserDetails festaUser) {
+        Event event = eventRepository.findById(eventId).orElse(null);
+        if (event == null) {
+            return 'n'; // 없는 이벤트면 false
+        }
+
+        boolean hasAlreadyApplied = entryRepository.existsByUserAndEvent(festaUser, event);
+        if (hasAlreadyApplied) {
+            return 'd'; // 한 유저가 같은 이벤트에 또 응모하려 하면 false
+        }
+
+        return 'g';
     }
 
-    public boolean isWithinArea(double latitude, double longtitude) {
-        return true;
+    public boolean isWithinArea(double latitude, double longtitude, double radius) {
+        double latDistance = Math.toRadians(latitude - HIU_LAT);
+        double lonDistance = Math.toRadians(longtitude - HIU_LON);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2) +
+                Math.cos(Math.toRadians(HIU_LAT)) * Math.cos(Math.toRadians(latitude)) *
+                        Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        double distance = EARTH_RADIUS * c;
+
+        return distance <= radius;
     }
 
     public boolean isUserBlacklist(String username){


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
1. 인증 중 오류가 발생하면 토큰 발급에 실패합니다.
2. 한 이벤트에 한 사람이 여러 번 응모할 수 없습니다.
3. 학교 바깥에 위치하면 응모할 수 없습니다. 홍익대학교 정문에서 후문까지의 거리는 600미터 가량입니다. 이를 참고해 적절한 판정 기준을 정해야 합니다. 현재는 테스트를 위해, 캠퍼스 정중앙에서 1km 넘게 떨어져있으면 실패하게 했습니다.

## 📸 작업 화면 스크린샷
<img width="793" alt="이벤트생성" src="https://github.com/user-attachments/assets/d97cea06-4cde-4578-b274-c51d691f2887">
어드민 토큰을 발급받고, 테스트용 이벤트를 생성했습니다.
<br>
<img width="786" alt="성남" src="https://github.com/user-attachments/assets/fc25bc5b-c2ec-4f42-9ec9-26691a5728ff">
현재 제 위치는 성남입니다. 이벤트용 토큰을 발급받을 수 없습니다.
<br>
<img width="789" alt="없는이벤트" src="https://github.com/user-attachments/assets/cf77440f-c33c-48cd-b88e-ffd28e89dd06">
존재하지 않는 이벤트에 응모할 수 없습니다.
<br>
<img width="805" alt="홍대정중앙" src="https://github.com/user-attachments/assets/2b95b02e-f0b2-4b50-9988-7d8a08176f99">
캠퍼스의 정중앙 위치에서 응모에 성공했습니다.
<br>
<img width="790" alt="2기숙사" src="https://github.com/user-attachments/assets/793d1df8-8d51-4b9d-b040-9a62fa9acd5e">
프로그램을 종료하고, 새로 시작해 이벤트를 다시 만들었습니다. 그 후 2기숙사 위치에서 응모에 성공했습니다.
<br>
<img width="795" alt="신촌역" src="https://github.com/user-attachments/assets/82804b52-2255-4c8e-a594-049c6dd0122d">
신촌역 위치에서는 응모에 실패했습니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]