### PR TITLE
[Feat] 분실물 게시물 관련 생성 & 삭제(상태 수정) 기능 구현

### DIFF
--- a/src/main/java/com/hyyh/festa/controller/LostAdminController.java
+++ b/src/main/java/com/hyyh/festa/controller/LostAdminController.java
@@ -23,19 +23,19 @@ public class LostAdminController {
     private final LostService lostService;
     private final BlackListService blackListService;
 
-//    @PatchMapping("/losts/{lostId}")
-//    public ResponseEntity<ResponseDTO<?>> deleteEvent(@PathVariable Long lostId,
-//                                                      @AuthenticationPrincipal UserDetails userDetails) {
-//        try {
-//            lostService.deleteLost(userDetails, lostId);
-//            ResponseDTO<?> responseDTO = ResponseDTO.custom(HttpStatus.NO_CONTENT,
-//                    "분실물 게시글 삭제 성공", Collections.emptyMap());
-//            return ResponseEntity.status(204).body(responseDTO);
-//        } catch (IllegalArgumentException e) {
-//            ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
-//            return ResponseEntity.status(404).body(responseDTO);
-//        }
-//    }
+    @PatchMapping("/losts/{lostId}")
+    public ResponseEntity<ResponseDTO<?>> deleteEvent(@PathVariable Long lostId,
+                                                      @AuthenticationPrincipal UserDetails userDetails) {
+        try {
+            GetAdminLostDTO deletedLost = lostService.deleteLost(userDetails, lostId);
+            ResponseDTO<?> responseDTO = ResponseDTO.ok(
+                    "분실물 게시글 삭제 성공", deletedLost);
+            return ResponseEntity.status(200).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
+            return ResponseEntity.status(404).body(responseDTO);
+        }
+    }
 
     @PostMapping("/blacklist")
     public ResponseEntity<ResponseDTO<?>> addToBlackList(@RequestBody BlackListRequestDTO blackListRequestDTO) {
@@ -64,8 +64,16 @@ public class LostAdminController {
                     "블랙 리스트 제거 성공", Collections.emptyMap());
             return ResponseEntity.status(204).body(responseDTO);
         } catch (IllegalArgumentException e) {
-            ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
-            return ResponseEntity.status(404).body(responseDTO);
+            String message = e.getMessage();
+            if (message.equals("존재하지 않는 분실물 게시판id")) {
+                ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
+                return ResponseEntity.status(404).body(responseDTO);
+            } else if (message.equals("이미 삭제 상태입니다.")) {
+                ResponseDTO<?> responseDTO = ResponseDTO.badRequest(e.getMessage());
+                return ResponseEntity.status(400).body(responseDTO);
+            }
+            ResponseDTO<?> responseDTO = ResponseDTO.forbidden(e.getMessage());
+            return ResponseEntity.status(403).body(responseDTO);
         }
     }
 

--- a/src/main/java/com/hyyh/festa/controller/LostController.java
+++ b/src/main/java/com/hyyh/festa/controller/LostController.java
@@ -1,5 +1,7 @@
 package com.hyyh.festa.controller;
 
+import com.hyyh.festa.dto.GetAdminLostDTO;
+import com.hyyh.festa.dto.LostRequestDTO;
 import com.hyyh.festa.dto.ResponseDTO;
 import com.hyyh.festa.service.LostService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,23 @@ import java.util.stream.Collectors;
 public class LostController {
 
     private final LostService lostService;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<?>> createLost(@AuthenticationPrincipal UserDetails userDetails,
+                                                     @RequestBody LostRequestDTO lostRequestDTO) {
+        try {
+            GetAdminLostDTO createdLost = lostService.createLost(userDetails, lostRequestDTO);
+            ResponseDTO<?> responseDTO = ResponseDTO.created("분실물 게시글 생성 성공", createdLost);
+            return ResponseEntity.status(201).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().equals("존재하지 않는 사용자id")) {
+                ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
+                return ResponseEntity.status(404).body(responseDTO);
+            }
+            ResponseDTO<?> responseDTO = ResponseDTO.forbidden(e.getMessage());
+            return ResponseEntity.status(403).body(responseDTO);
+        }
+    }
 
     @GetMapping
     public ResponseEntity<ResponseDTO<?>> getListLost(

--- a/src/main/java/com/hyyh/festa/domain/Lost.java
+++ b/src/main/java/com/hyyh/festa/domain/Lost.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
+@EntityListeners(AuditingEntityListener.class)
 public class Lost {
 
     @Id

--- a/src/main/java/com/hyyh/festa/service/LostService.java
+++ b/src/main/java/com/hyyh/festa/service/LostService.java
@@ -1,11 +1,20 @@
 package com.hyyh.festa.service;
 
+import com.hyyh.festa.domain.FestaUser;
 import com.hyyh.festa.domain.Lost;
+import com.hyyh.festa.domain.LostStatus;
 import com.hyyh.festa.dto.GetAdminLostDTO;
 import com.hyyh.festa.dto.GetUserLostDTO;
+import com.hyyh.festa.dto.LostRequestDTO;
 import com.hyyh.festa.repository.BlackListRepository;
+import com.hyyh.festa.repository.FestaUserRepository;
 import com.hyyh.festa.repository.LostRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.parameters.P;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,11 +31,36 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class LostService {
 
     private final LostRepository lostRepository;
+    private final FestaUserRepository festaUserRepository;
     private final BlackListRepository blackListRepository;
     private final BlackListService blackListService;
+
+    public GetAdminLostDTO createLost(UserDetails userDetails, LostRequestDTO lostRequestDTO) {
+        String username = userDetails.getUsername();
+        FestaUser festaUser = festaUserRepository.findByKakaoSub(username)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자id"));
+
+        if (blackListRepository.existsByFestaUserKakaoSub(username)) {
+            throw new IllegalArgumentException("차단된 사용자입니다.");
+        }
+
+        Lost lost = Lost.builder()
+                .festaUser(festaUser)
+                .foundLocation(lostRequestDTO.getFoundLocation())
+                .storageLocation(lostRequestDTO.getStorageLocation())
+                .content(lostRequestDTO.getContent())
+                .imageUrl(lostRequestDTO.getImageUrl())
+                .lostStatus(LostStatus.PUBLISHED)
+                .build();
+
+        Lost savedLost = lostRepository.save(lost);
+
+        return mapToAdminDTO(savedLost);
+    }
 
     public Optional<GetAdminLostDTO> getOneAdminLost(Long lostId) {
         return lostRepository.findById(lostId)
@@ -69,6 +103,20 @@ public class LostService {
         return lostList.stream().map(mapper).collect(Collectors.toList());
     }
 
+    public GetAdminLostDTO deleteLost(UserDetails userDetails, Long lostId) {
+        Lost lost = lostRepository.findById(lostId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 분실물 게시판id"));
+        System.out.println(userDetails.getAuthorities());
+        if (getAuthority(userDetails).equals("ADMIN")) {
+            if (lost.getLostStatus() != LostStatus.PUBLISHED)
+                throw new IllegalArgumentException("이미 삭제 상태입니다.");
+            lost.setLostStatus(LostStatus.DELETED);
+            lostRepository.save(lost);
+        } else {
+            throw new IllegalArgumentException("ADMIN이 아닙니다.");
+        }
+        return mapToAdminDTO(lost);
+    }
 
     private GetAdminLostDTO mapToAdminDTO(Lost lost) {
         boolean isUserBlocked = blackListService.isUserBlocked(lost.getFestaUser().getUsername());
@@ -95,5 +143,11 @@ public class LostService {
                 .imageUrl(lost.getImageUrl())
                 .createdAt(lost.getCreatedAt())
                 .build();
+    }
+
+    private String getAuthority(UserDetails userDetails) {
+        return userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining());
     }
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
1. 분실물 게시글을 게시하고 삭제하는 기능을 권한에 따라 구현했습니다.
2. createdAt에 값이 들어가지 않는 오류를 해결하기 위해 Lost엔티티에 어노테이션을 추가했습니다.

## 📸 작업 화면 스크린샷
<img width="681" alt="스크린샷 2024-08-09 오후 3 56 16" src="https://github.com/user-attachments/assets/273c347f-27f1-4ecf-8fbd-3755b776d186">
<img width="681" alt="스크린샷 2024-08-09 오후 3 54 55" src="https://github.com/user-attachments/assets/2c4710df-d357-4a1f-bf51-fdabf10d5ef2">
<br/> ㄴ 카카오 인증을 거치지 않은 사용자는 게시글을 작성할 수 없습니다.
<img width="681" alt="스크린샷 2024-08-09 오후 4 42 23" src="https://github.com/user-attachments/assets/85ce4439-4efa-4161-9dd2-fbc448fc9bec">
<br/> ㄴ 블랙리스트에 추가된 사용자는 게시글을 작성할 수 없습니다.
<img width="681" alt="스크린샷 2024-08-09 오후 4 23 33" src="https://github.com/user-attachments/assets/e47c6527-b3ac-479d-8f51-eab19176cfb3">
<br/> ㄴ admin이 아닌 사용자는 게시글을 삭제할 수 없습니다.
<img width="681" alt="스크린샷 2024-08-09 오후 4 23 46" src="https://github.com/user-attachments/assets/94a11768-7ae5-47df-a77c-1fc0d95d6253">
<br/> ㄴ 존재하지 않는 lostId에 접근하면 404
<img width="681" alt="스크린샷 2024-08-09 오후 4 41 13" src="https://github.com/user-attachments/assets/2acf953c-f9ed-4027-9ca1-8e7f34969360">
<br/> ㄴ 성공적으로 삭제되면 lostStatus가 PUBLISHED가 DELETED로 바뀝니다.


## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]