### PR TITLE
[Refactor] 분실물 리스트 조회 페이지네이션 수정사항 반영

### DIFF
--- a/src/main/java/com/hyyh/festa/controller/LostController.java
+++ b/src/main/java/com/hyyh/festa/controller/LostController.java
@@ -45,15 +45,15 @@ public class LostController {
     @GetMapping
     public ResponseEntity<ResponseDTO<?>> getListLost(
             @RequestParam(required = false)@DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(required = false) String userId,
             @AuthenticationPrincipal UserDetails userDetails){
         try {
             List<?> response;
             if (userDetails != null && getAuthority(userDetails).equals("ADMIN")){
-                response = lostService.getListAdminLost(page, date, userId);
+                response = lostService.getListAdminLost(page-1, date, userId);
             } else {
-                response = lostService.getListUserLost(page, date);
+                response = lostService.getListUserLost(page-1, date);
             }
 
             if (response.isEmpty()){

--- a/src/main/java/com/hyyh/festa/service/LostService.java
+++ b/src/main/java/com/hyyh/festa/service/LostService.java
@@ -81,7 +81,7 @@ public class LostService {
     }
 
     private <T> List<T> getListLostItems(int page, LocalDate date, String userId, Function<Lost, T> mapper) {
-        Pageable pageable = PageRequest.of(page, 12, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(page, 9, Sort.by("createdAt").descending());
 
         List<Lost> lostList;
         if (date == null) {


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?
분실물 게시글 리스트 조회 페이지네이션 관련 수정 사항을 반영하였습니다.

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
- 한 페이지에 9개로 게시글 제한으로 수정
- page 쿼리 파라미터를 1부터 시작 하도록 수정


## 📸 작업 화면 스크린샷
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/8963b2a0-8a15-4812-adde-8f09a70d51c7">
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/720e2078-f98c-4288-8929-0d0cacf1babe">
파라미터를 page=1로 했을 시, 또는 아무것도 넘기지 않으면 첫번째 페이지가 반환 됩니다.
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/8a17dc20-515e-45cb-831e-4cfc8efc19b9">
page=2로 하면, 두번째 페이지가 반환됩니다.
현재 게시글은 13개가 있고, 첫번째 페이지에서 lostId 13부터 5까지 (9개)
두번째 페이지에서 lostId 4부터 1까지 (4개)가 반환되고 있습니다.
최신순으로 정렬하기에 높은 숫자부터 반환되고 있습니다.


## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]