### PR TITLE
[Refactor]: ConcurrentHashMap 을 활용한 Booth 캐시

### DIFF
--- a/src/main/java/com/hyyh/festa/repository/BoothRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/BoothRepository.java
@@ -13,8 +13,4 @@ public interface BoothRepository extends JpaRepository<Booth, Long> {
 
     List<Booth> findTop3ByOrderByTotalLikeDesc();
 
-    // Pessimistic Lock을 적용한 부스 조회
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT b FROM Booth b WHERE b.id = :boothId")
-    Booth findByIdForLikeCountUpdate(Long boothId);
 }

--- a/src/main/java/com/hyyh/festa/service/BoothService.java
+++ b/src/main/java/com/hyyh/festa/service/BoothService.java
@@ -4,9 +4,12 @@ import com.hyyh.festa.domain.Booth;
 import com.hyyh.festa.dto.BoothGetResponse;
 import com.hyyh.festa.dto.BoothRankingGetResponse;
 import com.hyyh.festa.repository.BoothRepository;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,44 +23,59 @@ public class BoothService {
     private final BoothRepository boothRepository;
     private final SseService sseService;
 
+    // 캐시된 부스 객체를 ID로 관리
+    public static final Map<Long, Booth> cachedBooths = new ConcurrentHashMap<>();
+
+    // 부스 랭킹 캐시
     public List<Booth> rankings;
 
     @EventListener(ApplicationReadyEvent.class)
     public void init() {
+        // 컴포넌트 생성 시 캐시 및 rankings 초기화
+        boothRepository.findAll()
+                .forEach(booth -> cachedBooths.put(booth.getId(), booth));
         // 컴포넌트 생성시 rankings 초기화
         rankings = boothRepository.findTop3ByOrderByTotalLikeDesc();
     }
 
     @Transactional
     public Booth likeBooth(Long boothId) {
-        Booth booth = boothRepository.findByIdForLikeCountUpdate(boothId);
+        Booth booth = cachedBooths.get(boothId);
         booth.plusLikeCount();
+
+        // SSE 이벤트 배치 전송
         sseService.sendEventsBatched();
 
         return booth;
     }
 
     public List<BoothGetResponse> getBooths() {
-        return boothRepository.findAll().stream().map(BoothGetResponse::of).collect(Collectors.toList());
+        // 캐시된 부스 리스트를 기반으로 응답 생성
+        return cachedBooths.values().stream().map(BoothGetResponse::of).collect(Collectors.toList());
     }
 
     public Booth getBooth(Long boothId) {
-        return boothRepository.findById(boothId).get();
+
+        Booth booth = cachedBooths.get(boothId);
+        return booth;
     }
 
     @Transactional
     public void initalizeLikeCount() {
-        List<Booth> booths = boothRepository.findAll();
-        for (Booth booth : booths) {
+        // 캐시된 부스 객체 초기화
+        cachedBooths.values().forEach(booth -> {
             booth.setPreviousLike(0);
             booth.setTotalLike(0);
-        }
+        });
     }
 
     public List<BoothRankingGetResponse> getBoothsByRanking() {
+        // 캐시된 rankings 리스트를 기반으로 응답 생성
         return rankings.stream().map(BoothRankingGetResponse::of).collect(Collectors.toList());
     }
     public void setRankings() {
+        // 부스 순위 업데이트
         rankings = boothRepository.findTop3ByOrderByTotalLikeDesc();
     }
+
 }

--- a/src/main/java/com/hyyh/festa/service/ScheduledTasks.java
+++ b/src/main/java/com/hyyh/festa/service/ScheduledTasks.java
@@ -1,8 +1,10 @@
 package com.hyyh.festa.service;
 
+import com.hyyh.festa.repository.BoothRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -10,6 +12,7 @@ public class ScheduledTasks {
 
     private final BoothService boothService;
     private final SseService sseService;
+    private final BoothRepository boothRepository;
 
     @Scheduled(cron = "0 0 5 * * *")
     // 매일 오전 5시에 좋아요 초기화
@@ -27,6 +30,13 @@ public class ScheduledTasks {
     @Scheduled(fixedRate = 1000)
     public void eventsInvoker() {
         sseService.sendEvents();
+    }
+
+    @Scheduled(fixedRate = 10000)
+    @Transactional
+    public void saveCachedBoothsToDb() {
+        // 10초마다 캐시된 부스 객체를 DB에 저장
+        boothRepository.saveAll(BoothService.cachedBooths.values());
     }
 
 }

--- a/src/main/java/com/hyyh/festa/service/SseService.java
+++ b/src/main/java/com/hyyh/festa/service/SseService.java
@@ -3,6 +3,7 @@ package com.hyyh.festa.service;
 import com.hyyh.festa.domain.Booth;
 import com.hyyh.festa.dto.BoothLikeSseResponse;
 import com.hyyh.festa.repository.BoothRepository;
+import java.util.Collection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -27,6 +28,7 @@ public class SseService {
 
     private final BoothRepository boothRepository;
 
+
     private LocalDateTime latestEventSentAt = LocalDateTime.now();
 
     public void addEmitter(SseEmitter emitter) {
@@ -38,8 +40,7 @@ public class SseService {
     @Transactional
     public void sendEvents() {
 
-        // Booth 엔티티를 한번만 조회하고, 조회한 결과를 캐싱
-        List<Booth> booths = boothRepository.findAll();
+        Collection<Booth> booths = BoothService.cachedBooths.values();
 
         // BoothLikeSseResponse 객체 리스트를 생성
         List<BoothLikeSseResponse> boothLikeSseResponses = booths.stream()
@@ -68,7 +69,8 @@ public class SseService {
     }
 
     private boolean isIncreasedLikeGreaterThen(int threshold) {
-        return boothRepository.findAll().stream()
+
+        return BoothService.cachedBooths.values().stream()
                 .anyMatch(booth -> booth.getTotalLike() - booth.getPreviousLike() >= threshold);
     }
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [✅] 코드 개선
- [✅] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
# `ConcurrentHashMap` 을 활용한 Booth 캐시

## 1. 부스 객체의 캐시

부스 객체를 메모리에 캐시하고, 동시에 여러 스레드가 이 캐시에 접근하거나 수정할 수 있도록 하기 위해 ConcurrentHashMap을 사용할 수 있습니다. 캐시를 통해 데이터베이스 조회 부하를 줄일 수 있으며, 이는 성능 향상에 크게 기여할 수 있습니다. 예를 들어, SSE (Server-Sent Events)를 통해 클라이언트에게 실시간으로 좋아요 상태를 전송하는 경우, 좋아요 API 호출이 부스 데이터베이스 조회 및 업데이트와 관련이 있습니다. 이 경우, 데이터베이스에 매번 접근하는 대신 메모리에서 직접 정보를 조회하고 처리할 수 있어 성능이 크게 개선될 것이라고 생각합니다.

## 2. 캐시와 데이터베이스 동기화

캐시된 부스 객체는 10초마다 데이터베이스와 동기화됩니다. 이 과정은 `Scheduled` 어노테이션을 사용하여 주기적으로 실행되며, 캐시된 데이터를 데이터베이스에 저장하여 데이터의 일관성을 유지합니다. 이를 통해 최신 데이터가 데이터베이스에 반영되며, 캐시와 데이터베이스 간의 동기화 문제를 효과적으로 관리할 수 있습니다.


## ⚠️ PR하기 전에 확인해주세요

- [✅] 로컬테스트를 진행하셨나요?
- [✅] 머지할 브랜치를 확인하셨나요?
- [✅] 관련 label을 선택하셨나요?
