### PR TITLE
[Feat]: 당첨된 응모자를 취소시키는 기능 구현

### DIFF
--- a/src/main/java/com/hyyh/festa/config/SecurityConfig.java
+++ b/src/main/java/com/hyyh/festa/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/admin/events/*").hasAuthority("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/admin/entries").hasAuthority("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/admin/entries/*").hasAuthority("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/admin/entries/*").hasAuthority("ADMIN")
 
                         // 어드민 - 분실물
                         .requestMatchers(HttpMethod.DELETE, "/admin/losts/*").hasAuthority("ADMIN")

--- a/src/main/java/com/hyyh/festa/controller/EntryController.java
+++ b/src/main/java/com/hyyh/festa/controller/EntryController.java
@@ -1,8 +1,10 @@
 package com.hyyh.festa.controller;
 
+import com.hyyh.festa.domain.Entry;
 import com.hyyh.festa.domain.FestaUser;
 import com.hyyh.festa.dto.EntryPostRequest;
 import com.hyyh.festa.dto.EntryResponse;
+import com.hyyh.festa.dto.GetAdminLostDTO;
 import com.hyyh.festa.dto.ResponseDTO;
 import com.hyyh.festa.repository.FestaUserRepository;
 import com.hyyh.festa.service.EntryService;
@@ -64,6 +66,19 @@ public class EntryController {
             List<EntryResponse> entries = entryService.getEntriesByPrize(prize);
             ResponseDTO<?> responseDTO = ResponseDTO.ok("응모 목록 조회 성공", entries);
             return ResponseEntity.status(200).body(responseDTO);
+        } catch (IllegalArgumentException e) {
+            ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
+            return ResponseEntity.status(404).body(responseDTO);
+        }
+    }
+
+    @DeleteMapping("/admin/entries/{entryId}")
+    public ResponseEntity<ResponseDTO<?>> cancelWinner(@PathVariable Long entryId) {
+        try {
+            EntryResponse canceledWinner = entryService.cancelWinner(entryId);
+            ResponseDTO<?> responseDTO = ResponseDTO.notFound(
+                    "당첨 취소 성공");
+            return ResponseEntity.status(204).body(responseDTO);
         } catch (IllegalArgumentException e) {
             ResponseDTO<?> responseDTO = ResponseDTO.notFound(e.getMessage());
             return ResponseEntity.status(404).body(responseDTO);

--- a/src/main/java/com/hyyh/festa/domain/Entry.java
+++ b/src/main/java/com/hyyh/festa/domain/Entry.java
@@ -32,5 +32,6 @@ public class Entry {
     @Setter
     private int date;
 
+    @Setter
     private boolean isWinner;
 }

--- a/src/main/java/com/hyyh/festa/dto/EntryResponse.java
+++ b/src/main/java/com/hyyh/festa/dto/EntryResponse.java
@@ -16,4 +16,5 @@ public class EntryResponse {
     private String prize;
     private String comment;
     private int date;
+    private boolean isWinner;
 }

--- a/src/main/java/com/hyyh/festa/service/EntryService.java
+++ b/src/main/java/com/hyyh/festa/service/EntryService.java
@@ -16,6 +16,9 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -71,6 +74,18 @@ public class EntryService {
                 .collect(Collectors.toList());
     }
 
+    public EntryResponse cancelWinner(Long entryId) {
+        Entry entry = entryRepository.findById(entryId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 응모id"));
+        if (!entry.isWinner()) {
+            throw new IllegalArgumentException("이 응모는 당첨되지 않았습니다.");
+        }
+        entry.setWinner(FALSE);
+        entryRepository.save(entry);
+
+        return toEntryResponse(entry);
+    }
+
     private EntryResponse toEntryResponse(Entry entry) {
         return EntryResponse.builder()
                 .entryId(entry.getId())
@@ -79,6 +94,7 @@ public class EntryService {
                 .prize(String.valueOf(entry.getPrize()))
                 .comment(entry.getComment())
                 .date(entry.getDate())
+                .isWinner(entry.isWinner())
                 .build();
     }
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
1. 당첨된 사용자를 취소시키는(당첨에서 응모 상태로 바꾸는) 기능을 구현했습니다.
2. admin만 접근 가능하도록 SecurityConfig를 수정했습니다.

## 📸 작업 화면 스크린샷
<img width="694" alt="스크린샷 2024-08-27 오후 9 43 04" src="https://github.com/user-attachments/assets/dd3acb6c-1b34-4889-b074-7da4e575871e">
</br> ㄴ 존재하지 않는 응모id로 접근하면 404를 반환합니다.
<img width="694" alt="스크린샷 2024-08-27 오후 9 43 10" src="https://github.com/user-attachments/assets/f2ad1a98-cfc8-47b0-b5a9-e5552b6a11c2">
</br> ㄴ 당첨되지 않은 상태(응모 상태)인 응모id로 접근하면 404를 반환합니다.
<img width="694" alt="스크린샷 2024-08-27 오후 9 45 40" src="https://github.com/user-attachments/assets/236a906c-ead3-447e-afc2-78169d612629">
</br> ㄴ winner가 false로 제대로 바뀌는지 확인하기 위해 200을 반환하도록 했습니다. (테스트 코드에 대한 응답입니다)
<img width="694" alt="스크린샷 2024-08-27 오후 9 51 01" src="https://github.com/user-attachments/assets/02e5f78d-5ff7-46f0-9344-c50ddce6d70f">
</br> ㄴ 실제로 커밋한 코드에 대한 응답입니다.


## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]