### PR TITLE
[Fix] 전체 페이지 수 집계 오류 수정

### DIFF
--- a/src/main/java/com/hyyh/festa/controller/LostController.java
+++ b/src/main/java/com/hyyh/festa/controller/LostController.java
@@ -55,10 +55,10 @@ public class LostController {
 
             if (userDetails != null && getAuthority(userDetails).equals("ADMIN")){
                 losts = lostService.getLostListByAdmin(page-1, date, userId);
-                totalPage = lostService.countTotalPage();
+                totalPage = lostService.countTotalPage(date);
             } else {
                 losts = lostService.getLostListByUser(page-1, date);
-                totalPage = lostService.countPublishedTotalPage();
+                totalPage = lostService.countPublishedTotalPage(date);
             }
 
             if (losts.isEmpty()){

--- a/src/main/java/com/hyyh/festa/repository/LostRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/LostRepository.java
@@ -11,8 +11,11 @@ import java.util.List;
 
 @Repository
 public interface LostRepository extends JpaRepository<Lost, Long> {
+    List<Lost> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
     List<Lost> findAllByCreatedAtBetween(LocalDateTime start, LocalDateTime end, Pageable pageable);
     List<Lost> findAllByLostStatus(LostStatus lostStatus);
     List<Lost> findAllByLostStatus(LostStatus lostStatus, Pageable pageable);
+    List<Lost> findAllByLostStatusAndCreatedAtBetween(LostStatus lostStatus, LocalDateTime start, LocalDateTime end);
     List<Lost> findAllByLostStatusAndCreatedAtBetween(LostStatus lostStatus, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
 }

--- a/src/main/java/com/hyyh/festa/service/LostService.java
+++ b/src/main/java/com/hyyh/festa/service/LostService.java
@@ -170,13 +170,27 @@ public class LostService {
                 .collect(Collectors.joining());
     }
 
-    public int countTotalPage() {
-        List<Lost> losts = lostRepository.findAll();
+    public int countTotalPage(LocalDate date) {
+        List<Lost> losts;
+        if (date == null) {
+            losts = lostRepository.findAll();
+        } else {
+            LocalDateTime start = date.atStartOfDay();
+            LocalDateTime end = start.plusDays(1);
+            losts = lostRepository.findAllByCreatedAtBetween(start, end);
+        }
         return roundPageCount(losts.size());
     }
 
-    public int countPublishedTotalPage() {
-        List<Lost> losts = lostRepository.findAllByLostStatus(LostStatus.PUBLISHED);
+    public int countPublishedTotalPage(LocalDate date) {
+        List<Lost> losts;
+        if (date == null) {
+            losts = lostRepository.findAllByLostStatus(LostStatus.PUBLISHED);
+        } else {
+            LocalDateTime start = date.atStartOfDay();
+            LocalDateTime end = start.plusDays(1);
+            losts = lostRepository.findAllByLostStatusAndCreatedAtBetween(LostStatus.PUBLISHED, start, end);
+        }
         return roundPageCount(losts.size());
     }
 


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [x] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
분실물 게시글 리스트 조회에서 date 쿼리 스트링이 명시된 경우에 전체 페이지 수가 부정확하게 응답되는 오류를 수정

## 📸 작업 화면 스크린샷
기존 `POST /losts?date=2024-08-13` 의 응답이다. 전체 아이템 개수 2개로 `totalPage`는 1이 정확하지만, 2가 응답되고 있다.
<img width="572" alt="image" src="https://github.com/user-attachments/assets/2b24708c-be0c-48ea-a35d-efeb32e09bae">

이를 다음과 같이 올바로 응답되도록 수정했다.
<img width="646" alt="image" src="https://github.com/user-attachments/assets/8f813b08-6a5d-4983-8e85-9747b9db8598">

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]