### PR TITLE
[Feat] 어드민 페이지 경품 목록 조회 구현

### DIFF
--- a/src/main/java/com/hyyh/festa/controller/EntryController.java
+++ b/src/main/java/com/hyyh/festa/controller/EntryController.java
@@ -6,6 +6,7 @@ import com.hyyh.festa.dto.EntryPostRequest;
 import com.hyyh.festa.dto.EntryResponse;
 import com.hyyh.festa.dto.ResponseDTO;
 import com.hyyh.festa.dto.WinEntryResponse;
+import com.hyyh.festa.repository.EntryRepository;
 import com.hyyh.festa.repository.FestaUserRepository;
 import com.hyyh.festa.service.EntryService;
 import jakarta.validation.Valid;
@@ -22,6 +23,7 @@ import java.util.*;
 public class EntryController {
 
     private final EntryService entryService;
+    private final EntryRepository entryRepository;
     private final FestaUserRepository festaUserRepository;
 
     @PostMapping("/entries")
@@ -104,6 +106,23 @@ public class EntryController {
         List<WinEntryResponse> winningEntries = entryService.getWinningEntries();
 
         ResponseDTO<?> responseDTO = ResponseDTO.ok("당첨자 목록 조회 성공", winningEntries);
+        return ResponseEntity.status(200).body(responseDTO);
+    }
+
+    @GetMapping("/admin/entries/prizes")
+    public ResponseEntity<ResponseDTO<?>> getAdminPrizes() {
+        List<Map<String, Object>> prizeList = new ArrayList<>();
+
+        for (Prize p : Prize.values()) {
+            Map<String, Object> prizeInfo = new HashMap<>();
+            prizeInfo.put("prizeName", p.prizeName);
+            prizeInfo.put("quantity", p.quantity);
+            prizeInfo.put("entryCount", entryRepository.countByPrize(p));
+            prizeInfo.put("drawCompleted", entryService.drawCompleted(p));
+            prizeList.add(prizeInfo);
+        }
+
+        ResponseDTO<?> responseDTO = ResponseDTO.ok("경품 목록 조회 성공", prizeList);
         return ResponseEntity.status(200).body(responseDTO);
     }
 }

--- a/src/main/java/com/hyyh/festa/repository/EntryRepository.java
+++ b/src/main/java/com/hyyh/festa/repository/EntryRepository.java
@@ -15,4 +15,8 @@ public interface EntryRepository extends JpaRepository<Entry, Long> {
     List<Entry> findAllByPrize(Prize prize);
 
     List<Entry> findAllByIsWinner(boolean isWinner);
+
+    Long countByPrize(Prize prize);
+
+    Long countByPrizeAndIsWinner(Prize prize, boolean isWinner);
 }

--- a/src/main/java/com/hyyh/festa/service/EntryService.java
+++ b/src/main/java/com/hyyh/festa/service/EntryService.java
@@ -105,6 +105,10 @@ public class EntryService {
         return toEntryResponse(entry);
     }
 
+    public boolean drawCompleted(Prize prize) {
+        return prize.quantity == entryRepository.countByPrizeAndIsWinner(prize, true);
+    }
+
     private EntryResponse toEntryResponse(Entry entry) {
         return EntryResponse.builder()
                 .entryId(entry.getId())


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?
- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [ ] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
각 경품에 대한 응모 수, 추첨 완료 여부를 응답해주는 api를 추가했습니다.

## 📸 작업 화면 스크린샷
![스크린샷 2024-08-29 오후 2 25 07](https://github.com/user-attachments/assets/fd0a14c3-3e97-4698-b545-183334b6d24c)
![스크린샷 2024-08-29 오후 2 24 09](https://github.com/user-attachments/assets/3d0c6b27-1e00-466f-9e23-0ec568baa6c2)
상품 A, B에는 Entry가 각각 1개, 2개입니다. entryCount에 해당 값이 나타납니다.

<br>
<br>

![스크린샷 2024-08-29 오후 2 25 35](https://github.com/user-attachments/assets/5a487d06-0d14-4e57-90b0-3fdce59edf05)
![스크린샷 2024-08-29 오후 2 25 46](https://github.com/user-attachments/assets/edb11c09-cd5f-4abe-94b6-78169a08687f)
상품 B에 대해 당첨된 Entry가 3개가 된 상황입니다. 준비된 수량만큼 당첨되었으므로 상품 B의 drawCompleted에 true가 나타납니다.

<br>
<br>

![스크린샷 2024-08-29 오후 2 47 46](https://github.com/user-attachments/assets/2423ddb1-1fda-48d1-98fc-eb3f2bfbfd06)
![스크린샷 2024-08-29 오후 2 48 01](https://github.com/user-attachments/assets/f83d63ee-0618-4b79-acde-a2788cf76320)
수량이 7개인 상품 C에 대한 Entry를 7개 만듭니다. 모두 당첨은 아닙니다. 따라서 EntryCount는 7, drawCompleted는 false입니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]