### PR TITLE
[Fix] 이벤트 응모 시 후기 작성이 필수가 아니어도 되도록 변경

### DIFF
--- a/src/main/java/com/hyyh/festa/domain/Entry.java
+++ b/src/main/java/com/hyyh/festa/domain/Entry.java
@@ -27,7 +27,6 @@ public class Entry {
     @Enumerated(EnumType.STRING)
     private Prize prize;
 
-    @NotNull
     private String comment;
 
     @Setter

--- a/src/main/java/com/hyyh/festa/dto/EntryPostRequest.java
+++ b/src/main/java/com/hyyh/festa/dto/EntryPostRequest.java
@@ -22,7 +22,6 @@ public class EntryPostRequest {
     @NotBlank(message = "상품을 선택해야 합니다.")
     private String prize;
 
-    @NotBlank(message = "후기를 작성해주세요.")
     @Size(max = 100, message = "후기는 최대 100글자까지 입력할 수 있습니다.")
     private String comment;
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [ ] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
이벤트 응모 시 후기 작성은 사용자의 선택입니다.
이에 따라 후기가 필수가 아니어도 응모가 가능하도록 코드를 수정했습니다.

## 📸 작업 화면 스크린샷
<img width="709" alt="스크린샷 2024-09-09 오후 8 14 54" src="https://github.com/user-attachments/assets/fb12de13-fae5-453f-a9f5-490ca7cac26e">
</br>comment(후기)를 작성하지 않아도 응모가 가능합니다.

## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]