### PR TITLE
[Feat] 각 부스별 단과대(또는 총동아리 분류) 필드 도입

### DIFF
--- a/src/main/java/com/hyyh/festa/domain/Booth.java
+++ b/src/main/java/com/hyyh/festa/domain/Booth.java
@@ -1,9 +1,6 @@
 package com.hyyh.festa.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -22,11 +19,8 @@ public class Booth {
 
     private int previousLike = 0;
 
-    @Builder
-    public Booth(String boothName, int totalLike) {
-        this.boothName = boothName;
-        this.totalLike = totalLike;
-    }
+    @Enumerated(EnumType.STRING)
+    private BoothPart boothPart;
 
     public void plusLikeCount() {
         this.totalLike += 1;

--- a/src/main/java/com/hyyh/festa/domain/BoothPart.java
+++ b/src/main/java/com/hyyh/festa/domain/BoothPart.java
@@ -1,0 +1,28 @@
+package com.hyyh.festa.domain;
+
+public enum BoothPart {
+    ARCH("architecture"),
+    BE("businessEconomic"),
+    ENG("engineering"),
+    CONV("convergence"),
+    LIAR("liberalArts"),
+    ART("art"),
+    EDU("education"),
+    ATN("autonomous"),
+    CSC("clubScholarship"),
+    CSP("clubSports"),
+    CP("clubPerformance"),
+    CEL("clubExhibitionLeisure"),
+    CS("clueSociety"),
+    ;
+
+    String value;
+
+    BoothPart(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/hyyh/festa/dto/BoothLikeSseResponse.java
+++ b/src/main/java/com/hyyh/festa/dto/BoothLikeSseResponse.java
@@ -6,18 +6,12 @@ public record BoothLikeSseResponse(
 
         Long boothId,
 
-        String boothName,
-
-        int totalLike,
-
-        int increasedLike
+        int totalLike
 
 ) {
     public static BoothLikeSseResponse of(Booth booth) {
         return new BoothLikeSseResponse(
                 booth.getId(),
-                booth.getBoothName(),
-                booth.getTotalLike(),
-                booth.getTotalLike() - booth.getPreviousLike());
+                booth.getTotalLike());
     }
 }


### PR DESCRIPTION
## ✨ 어떤 이유로 PR를 하셨나요?

- [x] feature 병합
- [ ] 버그 수정(아래에 issue #를 남겨주세요)
- [ ] 코드 개선
- [x] 코드 수정
- [ ] 배포
- [ ] 기타(아래에 자세한 내용 기입해주세요)


## 📋 세부 내용 - 왜 해당 PR이 필요한지 작업 내용을 자세하게 설명해주세요
부스 좋아요 SSE 응답의 구조를 변경했습니다. 각 학과, 또는 동아리가 속한 단과대 또는 총동아리 구분 필드를 추가했습니다.

```json
{
  "engineering": [
    { "boothId": 3, "totalLike": 0 }
  ],
  "architecture": [
    { "boothId": 1, "totalLike": 7 },
    { "boothId": 2, "totalLike": 0 }
  ]
}
```

## 📸 작업 화면 스크린샷
![Screenshot 2024-09-16 at 17 10 06](https://github.com/user-attachments/assets/6b4d3fef-cdd1-474e-bc2d-7497766576fb)

각 단과대 또는 총동아리 소속의 주점이 리스트에 포함된 것을 확인할 수 있습니다.


## ⚠️ PR하기 전에 확인해주세요

- [x] 로컬테스트를 진행하셨나요?
- [x] 머지할 브랜치를 확인하셨나요?
- [x] 관련 label을 선택하셨나요?

## 🚨 관련 이슈 번호 [ ]